### PR TITLE
use Storage.setItem and Storage.getItem and fixed a bug in _storage.get method

### DIFF
--- a/lostorage.js
+++ b/lostorage.js
@@ -144,16 +144,17 @@
    };
 
    _storage.get = function (type, keys, fallback) {
-      
       fallback = fallback || undefined;
 
       if (utils.isArray(keys)) {
+         var result = {};
 
          for (var i = 0, l = keys.length; i < l; i++) {
             var key = keys[i];
-            result[key] = this.get(key, fallback);
+            result[key] = this.get(type, key, fallback);
          }
 
+         return result;
       } else return utils.retrieve(utils.unserialize(type.getItem(keys)), fallback);
 
    };


### PR DESCRIPTION
The first commit makes this code work as expected:

```
storage.set("getItem", "fail"); 
localStorage.getItem("foo");
```

The second commit fixes a bug: `result` was not declared and wasn't returned when `_storage.get` was called with an Array of keys
